### PR TITLE
Expose needed port

### DIFF
--- a/sonar-server/Dockerfile
+++ b/sonar-server/Dockerfile
@@ -14,4 +14,6 @@ RUN sed -i 's|#sonar.jdbc.user=sonar|sonar.jdbc.user=sonar|g' /opt/sonar/conf/so
 RUN sed -i 's|sonar.jdbc.url=jdbc:h2|#sonar.jdbc.url=jdbc:h2|g' /opt/sonar/conf/sonar.properties
 RUN sed -i 's|#sonar.jdbc.url=jdbc:mysql://localhost|sonar.jdbc.url=jdbc:mysql://${env:DB_PORT_3306_TCP_ADDR}|g' /opt/sonar/conf/sonar.properties 
 
+EXPOSE 9000
+
 CMD ["/opt/sonar/bin/linux-x86-64/sonar.sh","console"]


### PR DESCRIPTION
Expose port 9000 so that this can be automatically used with `-P` or with `docker-gen` tools (or the like), by giving proper information to `docker inspect`'s metadata.
