### PR TITLE
Changed java base image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+db:
+  build: ./sonar-mysql
+  ports:
+    - "3306:3306"
+
+web:
+  ports:
+    - "9000:9000"
+  build: ./sonar-server
+  links:
+    - db:db
+    

--- a/sonar-server/Dockerfile
+++ b/sonar-server/Dockerfile
@@ -1,4 +1,4 @@
-from dockerfile/java
+from java:latest
 maintainer Tiago Pires, tandrepires@gmail.com
 
 # RUN echo "deb http://archive.ubuntu.com/ubuntu trusty main universe" > /etc/apt/sources.list


### PR DESCRIPTION
Docker changed official base image url.

https://registry.hub.docker.com/_/java/
